### PR TITLE
Add offline dependency install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,18 @@ python scripts/create_admin.py --email admin@demo.com --name Admin --school Demo
 
 ---
 
-## 9 Roadmap
+## 9 Testing
+
+Install dependencies from `vendor/` and run Pytest:
+
+```bash
+./scripts/install_offline_deps.sh
+pytest
+```
+
+---
+
+## 10 Roadmap
 
 - [ ] Complete dashboard & navigation  
 - [ ] Fine‑tune embedding prompt for better matches  
@@ -139,7 +150,7 @@ python scripts/create_admin.py --email admin@demo.com --name Admin --school Demo
 
 ---
 
-## 10 License
+## 11 License
 
 MIT — see [`LICENSE`](./LICENSE).
 

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+from .router import router

--- a/scripts/install_offline_deps.sh
+++ b/scripts/install_offline_deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install Python dependencies from the local vendor directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+python -m pip install --no-index --find-links "$REPO_ROOT/vendor" -r "$REPO_ROOT/requirements.txt"


### PR DESCRIPTION
## Summary
- add `install_offline_deps.sh` to install Python dependencies from `vendor/`
- expose the API router package so FastAPI can boot
- document how to run tests offline

## Testing
- `./scripts/install_offline_deps.sh`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3c7fc53083338220447472e20502