### PR TITLE
Add API and service tests

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,14 +1,14 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.database import SessionLocal
+from app import database
 from app import crud, schemas
 
 router = APIRouter()
 
 
 def get_db():
-    db = SessionLocal()
+    db = database.SessionLocal()
     try:
         yield db
     finally:

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
 from app import database
-from app.api import router as api_router
+from app.api.router import router as api_router
 
 app = FastAPI(title="Student Profile SaaS")
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.main import app
+from app import database
+from app.models import models
+
+@pytest.fixture
+def client():
+    database.init()
+    database.Base.metadata.drop_all(bind=database.engine)
+    database.Base.metadata.create_all(bind=database.engine)
+    with TestClient(app) as client:
+        yield client
+    database.Base.metadata.drop_all(bind=database.engine)
+
+
+def test_create_and_get_student(client):
+    resp = client.post("/students", json={"name": "Alice", "school_id": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Alice"
+    resp = client.get("/students")
+    assert resp.status_code == 200
+    students = resp.json()
+    assert len(students) == 1
+    assert students[0]["name"] == "Alice"
+
+
+def test_create_and_get_job(client):
+    resp = client.post("/jobs", json={"title": "Engineer", "description": "dev"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Engineer"
+    resp = client.get("/jobs")
+    assert resp.status_code == 200
+    jobs = resp.json()
+    assert len(jobs) == 1
+    assert jobs[0]["title"] == "Engineer"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,8 @@
+import os
+import sys
 from fastapi.testclient import TestClient
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app.main import app
 
 client = TestClient(app)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.services import embeddings
+
+
+def test_embed_text_uses_openai(monkeypatch):
+    called = {}
+    def fake_create(input, model):
+        called['input'] = input
+        called['model'] = model
+        return {"data": [{"embedding": [1.0, 2.0, 3.0]}]}
+    monkeypatch.setattr(embeddings.openai, "api_key", "test")
+    monkeypatch.setattr(embeddings.openai.Embedding, "create", fake_create)
+    vec = embeddings.embed_text("hello")
+    assert vec == [1.0, 2.0, 3.0]
+    assert called['input'] == "hello"
+    assert called['model'] == "text-embedding-3-small"
+
+
+def test_embed_text_without_key(monkeypatch):
+    monkeypatch.setattr(embeddings.openai, "api_key", "")
+    vec = embeddings.embed_text("something")
+    assert vec == [0.0] * 1536

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import database
+from app.models import models
+from app.services import match
+
+@pytest.fixture
+def db():
+    database.init()
+    database.Base.metadata.drop_all(bind=database.engine)
+    database.Base.metadata.create_all(bind=database.engine)
+    session = database.SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        database.Base.metadata.drop_all(bind=database.engine)
+
+
+def test_match_job_to_students(db, monkeypatch):
+    s1 = models.Student(name="Alice", embedding="1 0 0")
+    s2 = models.Student(name="Bob", embedding="0 1 0")
+    db.add_all([s1, s2])
+    job = models.Job(title="Engineer", description="something")
+    db.add(job)
+    db.commit()
+    monkeypatch.setattr(match, "embed_text", lambda text: [1.0, 0.0, 0.0])
+    result = match.match_job_to_students(db, job, top_k=2)
+    assert [s.name for s in result] == ["Alice", "Bob"]


### PR DESCRIPTION
## Summary
- fix FastAPI router imports
- allow tests to import repo modules by inserting repo root to `sys.path`
- test creating and retrieving students and jobs
- mock OpenAI API in embed_text tests
- test `match_job_to_students`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3c8e86d48333a497f2ec8b593d89